### PR TITLE
g4ensdfstate: restore original install block to test bottling

### DIFF
--- a/Formula/g4ensdfstate.rb
+++ b/Formula/g4ensdfstate.rb
@@ -15,7 +15,7 @@ class G4ensdfstate < Formula
 
   def install
     (pkgshare/buildpath.basename.to_s).install Dir["./*"]
-  end  
+  end
 
   test do
     assert_predicate pkgshare, :exist?

--- a/Formula/g4ensdfstate.rb
+++ b/Formula/g4ensdfstate.rb
@@ -4,7 +4,7 @@ class G4ensdfstate < Formula
   url "https://geant4-data.web.cern.ch/geant4-data/datasets/G4ENSDFSTATE.2.3.tar.gz"
   sha256 "9444c5e0820791abd3ccaace105b0e47790fadce286e11149834e79c4a8e9203"
   license ""
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://ghcr.io/v2/drbenmorgan/geant4"
@@ -14,8 +14,8 @@ class G4ensdfstate < Formula
   end
 
   def install
-    pkgshare.install Dir["*"]
-  end
+    (pkgshare/buildpath.basename.to_s).install Dir["./*"]
+  end  
 
   test do
     assert_predicate pkgshare, :exist?


### PR DESCRIPTION
A question on [Homebrew Discussions](https://github.com/orgs/Homebrew/discussions/3813) gave a suggestion for resolving the issue with bottle checksums in GitHub actions. This is likely due to the presence of the `INSTALL_RECEIPT.json` in the bottle. The tests.yml workflow has been updated to use the `--only-json-tab` option, which should prevent this.

This MR just restores the original, common, way of installing data libraries to test this out.