### PR TITLE
CI: print out some information on permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
           brew audit drbenmorgan/geant4/g4ensdfstate --online --git --skip-style
           brew bottle --verbose --json drbenmorgan/geant4/g4ensdfstate --root-url=https://ghcr.io/v2/drbenmorgan/geant4 --only-json-tab
           brew bottle --merge --write --no-commit ./g4ensdfstate--2.3_3.*.bottle.json
+          tar -tvf ././g4ensdfstate--2.3_3.*.bottle.tar.gz
         if: github.event_name == 'pull_request'
         
       - name: Check umask, permissions after bottling

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,14 @@ jobs:
       - run: brew test-bot --only-setup
 
       - run: brew test-bot --only-tap-syntax
-      
-      - run: brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
-        if: github.event_name == 'pull_request'
+
+
+     - name: Run brew test-bot --only-formulae
+       run: |
+         mkdir ~/bottles
+         cd ~/bottles
+         brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
+       if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
           brew fetch --retry drbenmorgan/geant4/g4ensdfstate --build-bottle --force
           brew install --only-dependencies --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
           brew install --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
+          brew postinstall drbenmorgan/geant4/g4ensdfstate
           ls -larthR $(brew --cellar)
           brew audit drbenmorgan/geant4/g4ensdfstate --online --git --skip-style
           brew bottle --verbose --json drbenmorgan/geant4/g4ensdfstate --root-url=https://ghcr.io/v2/drbenmorgan/geant4 --only-json-tab

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,9 @@ jobs:
       # Try and get to just bottling step
       - name: Try bottle
         run: |
+          ls -larthR $(brew --cellar)
+          chmod g-w $(brew --cellar)
+          ls -larthR $(brew --cellar)
           brew fetch --retry drbenmorgan/geant4/g4ensdfstate --build-bottle --force
           brew install --only-dependencies --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
           brew install --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
               options: --user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED
             workdir: /github/home 
     runs-on: ${{ matrix.os }}
+    container: ${{matrix.container}}    
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,11 @@ jobs:
           echo $PWD
           umask
           ls -larth
+          ls -larth Formula
+          ls -larth $(brew --cellar)
           
          
-      - run: brew test-bot --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
+      - run: brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
         if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,9 +50,10 @@ jobs:
           brew fetch --retry drbenmorgan/geant4/g4ensdfstate --build-bottle --force
           brew install --only-dependencies --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
           brew install --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
+          ls -larthR $(brew --cellar)/g4ensdfstate
           brew audit drbenmorgan/geant4/g4ensdfstate --online --git --skip-style
           brew bottle --verbose --json drbenmorgan/geant4/g4ensdfstate --root-url=https://ghcr.io/v2/drbenmorgan/geant4 --only-json-tab
-          brew bottle --merge --write --no-commit ./g4ensdfstate--2.3_3.x86_64_linux.bottle.json
+          brew bottle --merge --write --no-commit ./g4ensdfstate--2.3_3.*.bottle.json
         if: github.event_name == 'pull_request'
         
       - name: Check umask, permissions after bottling

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,13 +47,12 @@ jobs:
       # Try and get to just bottling step
       - name: Try bottle
         run: |
-          ls -larthR $(brew --cellar)
-          chmod g-w $(brew --cellar)
+          id
           ls -larthR $(brew --cellar)
           brew fetch --retry drbenmorgan/geant4/g4ensdfstate --build-bottle --force
           brew install --only-dependencies --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
           brew install --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
-          ls -larthR $(brew --cellar)/g4ensdfstate
+          ls -larthR $(brew --cellar)
           brew audit drbenmorgan/geant4/g4ensdfstate --online --git --skip-style
           brew bottle --verbose --json drbenmorgan/geant4/g4ensdfstate --root-url=https://ghcr.io/v2/drbenmorgan/geant4 --only-json-tab
           brew bottle --merge --write --no-commit ./g4ensdfstate--2.3_3.*.bottle.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,13 +40,12 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-
-     - name: Run brew test-bot --only-formulae
-       run: |
-         mkdir ~/bottles
-         cd ~/bottles
-         brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
-       if: github.event_name == 'pull_request'
+      - name: Run brew test-bot --only-formulae
+        run: |
+          mkdir ~/bottles
+          cd ~/bottles
+          brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
+        if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,4 +52,4 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: '~/bottles/*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-12, macos-11]
+        include:
+          - os: ubuntu-22.04
+            container:
+              image: ghcr.io/homebrew/ubuntu22.04:master
+              options: --user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED
+            workdir: /github/home 
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,13 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
+      - name: Check umask, permissions
+        run: |
+          echo $PWD
+          umask
+          ls -larth
+          
+         
       - run: brew test-bot --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
         if: github.event_name == 'pull_request'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,8 +52,9 @@ jobs:
           brew fetch --retry drbenmorgan/geant4/g4ensdfstate --build-bottle --force
           brew install --only-dependencies --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
           brew install --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
-          brew postinstall drbenmorgan/geant4/g4ensdfstate
           ls -larthR $(brew --cellar)
+          mkdir testdir
+          ls -larthR
           brew audit drbenmorgan/geant4/g4ensdfstate --online --git --skip-style
           brew bottle --verbose --json drbenmorgan/geant4/g4ensdfstate --root-url=https://ghcr.io/v2/drbenmorgan/geant4 --only-json-tab
           brew bottle --merge --write --no-commit ./g4ensdfstate--2.3_3.*.bottle.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,14 @@ jobs:
          
       - run: brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
         if: github.event_name == 'pull_request'
+        
+      - name: Check umask, permissions after bottling
+        run: |
+          echo $PWD
+          umask
+          ls -larth
+          ls -larth Formula
+          ls -larth $(brew --cellar)
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,41 +39,9 @@ jobs:
       - run: brew test-bot --only-setup
 
       - run: brew test-bot --only-tap-syntax
-
-      - name: Check umask, permissions
-        run: |
-          echo $PWD
-          umask
-          ls -larthR
-          ls -larthR $(brew --cellar)
-          
-         
-#      - run: brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
-#        if: github.event_name == 'pull_request'
-
-      # Try and get to just bottling step
-      - name: Try bottle
-        run: |
-          id
-          ls -larthR $(brew --cellar)
-          brew fetch --retry drbenmorgan/geant4/g4ensdfstate --build-bottle --force
-          brew install --only-dependencies --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
-          brew install --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
-          ls -larthR $(brew --cellar)
-          mkdir testdir
-          ls -larthR
-          brew audit drbenmorgan/geant4/g4ensdfstate --online --git --skip-style
-          brew bottle --verbose --json drbenmorgan/geant4/g4ensdfstate --root-url=https://ghcr.io/v2/drbenmorgan/geant4 --only-json-tab
-          brew bottle --merge --write --no-commit ./g4ensdfstate--2.3_3.*.bottle.json
-          tar -tvf ././g4ensdfstate--2.3_3.*.bottle.tar.gz
+      
+      - run: brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
         if: github.event_name == 'pull_request'
-        
-      - name: Check umask, permissions after bottling
-        run: |
-          echo $PWD
-          umask
-          ls -larthR
-          ls -larthR $(brew --cellar)
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,8 @@ jobs:
         run: |
           echo $PWD
           umask
-          ls -larth
-          ls -larth Formula
-          ls -larth $(brew --cellar)
+          ls -larthR
+          ls -larthR $(brew --cellar)
           
          
       - run: brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
@@ -49,9 +48,8 @@ jobs:
         run: |
           echo $PWD
           umask
-          ls -larth
-          ls -larth Formula
-          ls -larth $(brew --cellar)
+          ls -larthR
+          ls -larthR $(brew --cellar)
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,18 @@ jobs:
           ls -larthR $(brew --cellar)
           
          
-      - run: brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
+#      - run: brew test-bot --debug --only-formulae --only-json-tab --root-url=https://ghcr.io/v2/drbenmorgan/geant4
+#        if: github.event_name == 'pull_request'
+
+      # Try and get to just bottling step
+      - name: Try bottle
+        run: |
+          brew fetch --retry drbenmorgan/geant4/g4ensdfstate --build-bottle --force
+          brew install --only-dependencies --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
+          brew install --verbose --build-bottle drbenmorgan/geant4/g4ensdfstate
+          brew audit drbenmorgan/geant4/g4ensdfstate --online --git --skip-style
+          brew bottle --verbose --json drbenmorgan/geant4/g4ensdfstate --root-url=https://ghcr.io/v2/drbenmorgan/geant4 --only-json-tab
+          brew bottle --merge --write --no-commit ./g4ensdfstate--2.3_3.x86_64_linux.bottle.json
         if: github.event_name == 'pull_request'
         
       - name: Check umask, permissions after bottling

--- a/Formula/g4ensdfstate.rb
+++ b/Formula/g4ensdfstate.rb
@@ -4,7 +4,7 @@ class G4ensdfstate < Formula
   url "https://geant4-data.web.cern.ch/geant4-data/datasets/G4ENSDFSTATE.2.3.tar.gz"
   sha256 "9444c5e0820791abd3ccaace105b0e47790fadce286e11149834e79c4a8e9203"
   license ""
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://ghcr.io/v2/drbenmorgan/geant4"


### PR DESCRIPTION
macOS/Linux bottles for data differ due to directory `g+w` permissions being present on Linux, as well as `g+w` on file in `.brew` directory. This PR is pure CI only to try and print out some info on masks, permissions to see where the difference is arising. 